### PR TITLE
feat(docs): Markdown 展示路由中间件 (issue #4)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -350,3 +350,9 @@ instead」）。`@koa/router` 是官方维护的继任包，API 与 koa-router *
 ### 影响范围
 
 仅文档生成器（`generate_swagger` / `generate_postman`），不涉及运行时校验、路由绑定或类型推导。已声明 response schema 的项目重新生成文档即可看到变化；未声明的项目输出与之前完全一致。
+
+## v3.2.5 — Markdown 文档展示中间件（issue #4）
+
+### 新增（非 breaking）
+
+- **Markdown 文档输出路由的中间件函数名列表**：`middlewares` 此前已通过 `.middlewares()` 注册并经 `DOC_FIELD` 采集进文档数据，但四个生成器无一渲染。现 Markdown 在「请求地址」行下方输出 `中间件：`<fn1>`, `<fn2>``（取具名函数的 `fn.name`，匿名函数跳过），便于在文档中看到路由的处理链。Swagger/Postman 不受影响（OpenAPI 标准无中间件字段，强行加入反而不被消费方识别）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erest",
-  "version": "3.2.2",
+  "version": "3.2.5",
   "description": "Framework-agnostic REST API framework with Zod validation, auto docs & test scaffolding. Express/Koa/@leizm/web adapters as separate packages.",
   "type": "module",
   "main": "dist/lib/index.js",

--- a/packages/erest-express/package.json
+++ b/packages/erest-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erest/express",
-  "version": "3.2.2",
+  "version": "3.2.5",
   "description": "Express adapter for erest",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/erest-gen/package.json
+++ b/packages/erest-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erest/gen",
-  "version": "3.2.2",
+  "version": "3.2.5",
   "description": "erest codegen CLI：从 Zod schema 生成 handler 骨架等（实验性，独立于 erest 主版本演进）",
   "type": "module",
   "bin": {

--- a/packages/erest-koa/package.json
+++ b/packages/erest-koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erest/koa",
-  "version": "3.2.2",
+  "version": "3.2.5",
   "description": "Koa adapter for erest",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/erest-leizmweb/package.json
+++ b/packages/erest-leizmweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@erest/leizmweb",
-  "version": "3.2.2",
+  "version": "3.2.5",
   "description": "@leizm/web adapter for erest",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/lib/plugin/generate_markdown/apis.ts
+++ b/src/lib/plugin/generate_markdown/apis.ts
@@ -109,6 +109,17 @@ export default function apiDocs(data: IDocData) {
     const line = [`## ${tit} ${tested}`];
     line.push(`\n请求地址：**${method}** \`${item.realPath}\``);
 
+    // 中间件（issue #4）：输出具名中间件的函数名，匿名函数跳过
+    const mids = item.middlewares as Set<Function> | undefined;
+    if (mids && mids.size > 0) {
+      const names = Array.from(mids)
+        .map((fn) => (typeof fn === "function" ? fn.name : ""))
+        .filter((n) => n && n !== "anonymous");
+      if (names.length > 0) {
+        line.push(`\n中间件：${names.map((n) => `\`${n}\``).join(", ")}`);
+      }
+    }
+
     if (item.description) {
       line.push(
         (item.description as string)

--- a/src/test/test-docs-plugins.ts
+++ b/src/test/test-docs-plugins.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import generateAxios from "../lib/plugin/generate_axios";
+import apiDocs from "../lib/plugin/generate_markdown/apis";
 import generatePostman from "../lib/plugin/generate_postman";
 import generateSwagger, { buildSwagger } from "../lib/plugin/generate_swagger";
 
@@ -142,5 +143,51 @@ describe("postman response 示例（issue #6）", () => {
     const postman = capturePostman({});
     const item = postman.item[0].item[0];
     expect(item.response).toBeUndefined();
+  });
+});
+
+describe("markdown 中间件展示（issue #4）", () => {
+  function buildWith(middlewares?: Set<Function>) {
+    const data = {
+      info: {},
+      group: { G: "G" },
+      types: {},
+      apis: {
+        "get_/test": {
+          method: "get",
+          path: "/test",
+          realPath: "/test",
+          group: "G",
+          title: "测试路由",
+          examples: [],
+          requiredOneOf: [],
+          ...(middlewares ? { middlewares } : {}),
+        },
+      },
+    } as any;
+    return apiDocs(data);
+  }
+
+  test("有具名中间件时，Markdown 输出中间件名列表", () => {
+    function authCheck() {}
+    function logRequest() {}
+    const { list } = buildWith(new Set([authCheck, logRequest]));
+    const content = list[0].content;
+    expect(content).toContain("authCheck");
+    expect(content).toContain("logRequest");
+  });
+
+  test("无中间件时不报错，且不输出中间件行", () => {
+    const { list } = buildWith(undefined);
+    const content = list[0].content;
+    expect(content).not.toMatch(/中间件/);
+  });
+
+  test("匿名中间件不输出空名（跳过无 name 的函数）", () => {
+    const anon = function () {};
+    const { list } = buildWith(new Set([anon]));
+    const content = list[0].content;
+    // 不应出现「中间件：」后跟空列表
+    expect(content).not.toMatch(/中间件：\s*$/);
   });
 });


### PR DESCRIPTION
## 关联 issue
Closes #4

## 改动内容
`middlewares` 此前已通过 `.middlewares()` 注册并经 `DOC_FIELD` 采集进文档数据，但四个生成器无一渲染。

- Markdown 在「请求地址」行下方输出 `中间件：<fn1>, <fn2>`（取具名函数 `fn.name`，匿名函数跳过）
- **Swagger/Postman 不改动**：OpenAPI 标准无 middleware 字段，强行加入不被消费方识别

## 测试
- 新增 3 个回归测试（具名中间件 / 无中间件 / 匿名跳过）
- 全量 `npm run test:lib`：317 → 320 全绿
- `tsc --noEmit` 通过

## 版本
bump 3.2.1 → **3.2.5**，已登记 MIGRATION

## 合并顺序提示
本系列共 4 个 PR，请按版本号顺序合并（3.2.2 → 3.2.3 → 3.2.4 → **3.2.5**）。
⚠️ 合并时 `MIGRATION.md` 与 `package.json` 可能冲突，需 rebase 解冲突。

## 相关
issue #3（API 版本）已 wontfix 关闭：与「热路径零分配」「hook 不参与控制流」架构红线冲突，已有 `groups[].prefix` 替代方案。